### PR TITLE
new: added OriginalData() to bahamut.Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -24,6 +24,7 @@ type bcontext struct {
 	outputData            any
 	ctx                   context.Context
 	inputData             any
+	originalData          elemental.Identifiable
 	claimsMap             map[string]string
 	responseWriter        ResponseWriter
 	request               *elemental.Request
@@ -90,6 +91,10 @@ func (c *bcontext) InputData() any {
 
 func (c *bcontext) SetInputData(data any) {
 	c.inputData = data
+}
+
+func (c *bcontext) OriginalData() any {
+	return c.originalData
 }
 
 func (c *bcontext) OutputData() any {
@@ -215,6 +220,7 @@ func (c *bcontext) Duplicate() Context {
 	c2.outputCookies = append(c2.outputCookies, c.outputCookies...)
 	c2.responseWriter = c.responseWriter
 	c2.disableOutputDataPush = c.disableOutputDataPush
+	c2.originalData = c.originalData
 
 	for k, v := range c.claimsMap {
 		c2.claimsMap[k] = v

--- a/context_mock.go
+++ b/context_mock.go
@@ -25,6 +25,7 @@ type MockContext struct {
 	MockCtx                   context.Context
 	MockOutputData            any
 	MockInputData             any
+	MockOriginalData          any
 	MockMetadata              map[any]any
 	MockClaimsMap             map[string]string
 	MockResponseWriter        ResponseWriter
@@ -83,6 +84,11 @@ func (c *MockContext) InputData() any {
 // SetInputData sets the context's input data.
 func (c *MockContext) SetInputData(data any) {
 	c.MockInputData = data
+}
+
+// OriginalData returns the context's original data.
+func (c *MockContext) OriginalData() any {
+	return c.MockOriginalData
 }
 
 // OutputData returns the context's output data.
@@ -215,6 +221,7 @@ func (c *MockContext) Duplicate() Context {
 	c2.MockOutputCookies = append(c2.MockOutputCookies, c.MockOutputCookies...)
 	c2.MockResponseWriter = c.MockResponseWriter
 	c2.MockDisableOutputDataPush = c.MockDisableOutputDataPush
+	c2.MockOriginalData = c.MockOriginalData
 
 	for k, v := range c.MockClaimsMap {
 		c2.MockClaimsMap[k] = v

--- a/context_mock_test.go
+++ b/context_mock_test.go
@@ -78,6 +78,7 @@ func TestMockContext_Duplicate(t *testing.T) {
 
 		cookies := []*http.Cookie{{}, {}}
 		rwriter := func(http.ResponseWriter) int { return 0 }
+		od := testmodel.NewList()
 
 		ctx := NewMockContext(context.Background())
 		ctx.MockRequest = req
@@ -94,6 +95,7 @@ func TestMockContext_Duplicate(t *testing.T) {
 		ctx.AddOutputCookies(cookies[0], cookies[1])
 		ctx.SetResponseWriter(rwriter)
 		ctx.SetDisableOutputDataPush(true)
+		ctx.MockOriginalData = od
 
 		Convey("When I call the Duplicate method", func() {
 
@@ -117,6 +119,7 @@ func TestMockContext_Duplicate(t *testing.T) {
 				So(ctx.MockOutputCookies, ShouldResemble, cookies)
 				So(ctx.MockResponseWriter, ShouldEqual, rwriter)
 				So(ctx.MockDisableOutputDataPush, ShouldEqual, ctx.MockDisableOutputDataPush)
+				So(ctx.OriginalData(), ShouldEqual, ctx.OriginalData())
 			})
 		})
 	})

--- a/context_test.go
+++ b/context_test.go
@@ -127,6 +127,7 @@ func TestContext_Duplicate(t *testing.T) {
 
 		cookies := []*http.Cookie{{}, {}}
 		rwriter := func(http.ResponseWriter) int { return 0 }
+		od := testmodel.NewList()
 
 		ctx := newContext(context.Background(), req)
 		ctx.SetCount(10)
@@ -142,6 +143,7 @@ func TestContext_Duplicate(t *testing.T) {
 		ctx.AddOutputCookies(cookies[0], cookies[1])
 		ctx.SetResponseWriter(rwriter)
 		ctx.SetDisableOutputDataPush(true)
+		ctx.originalData = od
 
 		Convey("When I call the Duplicate method", func() {
 
@@ -163,7 +165,9 @@ func TestContext_Duplicate(t *testing.T) {
 				So(ctx.outputCookies, ShouldResemble, ctx2.(*bcontext).outputCookies)
 				So(ctx.outputCookies, ShouldResemble, cookies)
 				So(ctx.responseWriter, ShouldEqual, rwriter)
-				So(ctx.disableOutputDataPush, ShouldEqual, ctx.disableOutputDataPush)
+				So(ctx.disableOutputDataPush, ShouldEqual, ctx2.(*bcontext).disableOutputDataPush)
+				So(ctx.OriginalData(), ShouldEqual, ctx2.OriginalData())
+
 			})
 		})
 	})

--- a/dispatchers.go
+++ b/dispatchers.go
@@ -404,6 +404,8 @@ func dispatchPatchOperation(
 			return err
 		}
 
+		ctx.originalData = identifiable
+
 		patchable, ok := identifiable.(elemental.Patchable)
 		if !ok {
 			err := elemental.NewError("Bad Request", "Identifiable is not patchable", "bahamut", http.StatusBadRequest)

--- a/dispatchers_test.go
+++ b/dispatchers_test.go
@@ -1632,9 +1632,10 @@ func TestDispatchers_dispatchPatchOperation(t *testing.T) {
 		}
 
 		var retrieverCalled int
+		original := &testmodel.List{ID: expectedID, Name: "will be patched"}
 		retriever := func(req *elemental.Request) (elemental.Identifiable, error) {
 			retrieverCalled++
-			return &testmodel.List{ID: expectedID, Name: "will be patched"}, nil
+			return original, nil
 		}
 
 		auditer := &mockAuditer{}
@@ -1650,6 +1651,7 @@ func TestDispatchers_dispatchPatchOperation(t *testing.T) {
 			So(retrieverCalled, ShouldEqual, 1)
 			So(auditer.GetCallCount(), ShouldEqual, expectedNbCalls)
 			So(ctx.outputData, ShouldResemble, &testmodel.SparseList{ID: &expectedID, Name: &expectedName})
+			So(ctx.originalData, ShouldEqual, original)
 			So(len(pusher.events), ShouldEqual, 2)
 			So(pusher.events[0].Type, ShouldEqual, elemental.EventDelete)
 			So(pusher.events[1].Type, ShouldEqual, elemental.EventUpdate)

--- a/interfaces.go
+++ b/interfaces.go
@@ -116,6 +116,10 @@ type Context interface {
 	// SetInputData replaces the current input data.
 	SetInputData(any)
 
+	// OriginalData returns the data that may have been retrieved using
+	// the configured IdentifiableRetriever during the Update process.
+	OriginalData() any
+
 	// OutputData returns the current output data.
 	OutputData() any
 


### PR DESCRIPTION
Allows to access the data retrieved using the bahamut.IdentifiableRetriever. Only available for Patch operation.