### PR TITLE
new: better error in case of permission errors

### DIFF
--- a/processor_helpers.go
+++ b/processor_helpers.go
@@ -12,6 +12,7 @@
 package bahamut
 
 import (
+	"fmt"
 	"net/http"
 
 	"go.acuvity.ai/elemental"
@@ -74,7 +75,16 @@ func CheckAuthorization(authorizers []Authorizer, ctx Context) (err error) {
 		case AuthActionOK:
 			return nil
 		case AuthActionKO:
-			return elemental.NewError("Forbidden", "You are not allowed to access this resource.", "bahamut", http.StatusForbidden)
+			return elemental.NewError(
+				"Forbidden",
+				fmt.Sprintf(
+					"You are not allowed to perform '%s' on '%s'",
+					ctx.Request().Operation,
+					ctx.Request().Identity.Category,
+				),
+				"bahamut",
+				http.StatusForbidden,
+			)
 		case AuthActionContinue:
 			continue
 		}


### PR DESCRIPTION
Instead of saying "you are not allowed to access this resource", this patch makes it say "you are not allowed to perform X on Y"

Long overdue..