### PR TITLE
metrics: add MeasureGenericRequest to MetricsMananger

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -59,6 +59,10 @@ func (m *fakeMetricManager) MeasureRequest(method string, path string) bahamut.F
 	return func(code int, span opentracing.Span) time.Duration { return 0 }
 }
 
+func (m *fakeMetricManager) MeasureGenericRequest(method string, path string) bahamut.FinishMeasurementFunc {
+	return func(code int, span opentracing.Span) time.Duration { return 0 }
+}
+
 func (m *fakeMetricManager) RegisterWSConnection() {
 	atomic.AddInt64(&m.registerWSConnectionCalled, 1)
 }

--- a/health_server_test.go
+++ b/health_server_test.go
@@ -40,6 +40,9 @@ type testMetricsManager struct{}
 func (m *testMetricsManager) MeasureRequest(method string, path string) FinishMeasurementFunc {
 	return nil
 }
+func (m *testMetricsManager) MeasureGenericRequest(method string, path string) FinishMeasurementFunc {
+	return nil
+}
 func (m *testMetricsManager) RegisterWSConnection()    {}
 func (m *testMetricsManager) UnregisterWSConnection()  {}
 func (m *testMetricsManager) RegisterTCPConnection()   {}

--- a/metrics.go
+++ b/metrics.go
@@ -23,10 +23,27 @@ type FinishMeasurementFunc func(code int, span opentracing.Span) time.Duration
 
 // A MetricsManager handles Prometheus Metrics Management
 type MetricsManager interface {
+
+	// MeasureRequest can be used to measure bahamut request. The url will be
+	// sanitized and eventual id will be switched to :id
 	MeasureRequest(method string, path string) FinishMeasurementFunc
+
+	// MeasureGenericRequest measures an http request without further sanitization.
+	// This can be used to measure random url.
+	MeasureGenericRequest(method string, path string) FinishMeasurementFunc
+
+	// RegisterWSConnection will increment the counter of current websocket connections
 	RegisterWSConnection()
+
+	// UnregisterWSConnection deacreases the counter of currently active websocket connections.
 	UnregisterWSConnection()
+
+	// RegisterTCPConnection will increment the counter of current TCP connections
 	RegisterTCPConnection()
+
+	// UnregisterTCPConnection deacreases the counter of currently active TCP connections.
 	UnregisterTCPConnection()
+
+	// Write writes the state of the measurement into the response writer.
 	Write(w http.ResponseWriter, r *http.Request)
 }

--- a/metrics_prometheus.go
+++ b/metrics_prometheus.go
@@ -131,8 +131,19 @@ func newPrometheusMetricsManager(registerer prometheus.Registerer) MetricsManage
 }
 
 func (c *prometheusMetricsManager) MeasureRequest(method string, path string) FinishMeasurementFunc {
+	return c.measureRequest(method, path, true)
+}
 
-	surl := sanitizePath(path)
+func (c *prometheusMetricsManager) MeasureGenericRequest(method string, path string) FinishMeasurementFunc {
+	return c.measureRequest(method, path, false)
+}
+
+func (c *prometheusMetricsManager) measureRequest(method string, path string, sanitize bool) FinishMeasurementFunc {
+
+	surl := path
+	if sanitize {
+		surl = sanitizePath(path)
+	}
 
 	timer := prometheus.NewTimer(
 		prometheus.ObserverFunc(

--- a/rest_server_test.go
+++ b/rest_server_test.go
@@ -307,6 +307,9 @@ type mockMetricsManager struct {
 func (m *mockMetricsManager) MeasureRequest(method string, url string) FinishMeasurementFunc {
 	return m.measureFunc
 }
+func (m *mockMetricsManager) MeasureGenericRequest(method string, url string) FinishMeasurementFunc {
+	return m.measureFunc
+}
 func (m *mockMetricsManager) RegisterWSConnection()                        {}
 func (m *mockMetricsManager) UnregisterWSConnection()                      {}
 func (m *mockMetricsManager) RegisterTCPConnection()                       {}


### PR DESCRIPTION
This is the same as MeasureRequest but does not assume the url is a bahamut API and will skip attempt to sanitize it