### PR TITLE
ratelimit: clean up options about rate limiting

### DIFF
--- a/gateway/extractors.go
+++ b/gateway/extractors.go
@@ -47,9 +47,9 @@ func (f defaultSourceExtractor) ExtractSource(r *http.Request) (string, error) {
 	return fmt.Sprintf("%d", xxhash.Sum64([]byte(v))), nil
 }
 
-type defaultTCPSourceExtractor struct{}
+type defaultIPSourceExtractor struct{}
 
-func (f defaultTCPSourceExtractor) ExtractSource(r *http.Request) (string, error) {
+func (f defaultIPSourceExtractor) ExtractSource(r *http.Request) (string, error) {
 
 	return r.RemoteAddr, nil
 }

--- a/gateway/extractors_test.go
+++ b/gateway/extractors_test.go
@@ -121,14 +121,14 @@ func Test_defaultTCPSourceExtractor_ExtractSource(t *testing.T) {
 	}
 	tests := []struct {
 		name    string
-		f       defaultTCPSourceExtractor
+		f       defaultIPSourceExtractor
 		args    args
 		want    string
 		wantErr bool
 	}{
 		{
 			"source",
-			defaultTCPSourceExtractor{},
+			defaultIPSourceExtractor{},
 			args{
 				&http.Request{RemoteAddr: "1.1.1.1"},
 			},
@@ -138,7 +138,7 @@ func Test_defaultTCPSourceExtractor_ExtractSource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := defaultTCPSourceExtractor{}
+			f := defaultIPSourceExtractor{}
 			got, err := f.ExtractSource(tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("defaultTCPSourceExtractor.ExtractSource() error = %v, wantErr %v", err, tt.wantErr)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -203,15 +203,15 @@ func New(listenAddr string, upstreamer Upstreamer, options ...Option) (Gateway, 
 		return nil, fmt.Errorf("unable to initialize request buffer: %w", err)
 	}
 
-	if cfg.tcpClientMaxConnectionsEnabled {
+	if cfg.clientMaxConnectionsEnabled {
 
 		if topProxyHTTPHandler, err = connlimit.New(
 			topProxyHTTPHandler,
 			utils.ExtractorFunc(func(req *http.Request) (token string, amount int64, err error) {
-				token, err = cfg.tcpClientSourceExtractor.ExtractSource(req)
+				token, err = cfg.sourceExtractor.ExtractSource(req)
 				return token, 1, err
 			}),
-			int64(cfg.tcpClientMaxConnections),
+			int64(cfg.clientMaxConnections),
 			connlimit.ErrorHandler(&errorHandler{corsOriginInjector: s.corsOriginInjectorFunc}),
 		); err != nil {
 			return nil, fmt.Errorf("unable to initialize connection limiter: %w", err)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -137,7 +137,7 @@ func TestGateway(t *testing.T) {
 				OptionEnableProxyProtocol(true, "0.0.0.0/0"),
 				OptionSourceRateLimitingDynamic(&simpleLimiter{}),
 				OptionTCPGlobalRateLimiting(200.0, 200.0),
-				OptionTCPClientMaxConnections(100),
+				OptionSourceMaxConnections(100),
 				OptionUpstreamConfig(0, 0, 0, 0, 0, "NetworkErrorRatio() > 0.5", false),
 				OptionEnableTrace(true),
 				OptionMetricsManager(mm),
@@ -497,7 +497,7 @@ func TestGateway(t *testing.T) {
 				OptionServerTLSConfig(&tls.Config{Certificates: []tls.Certificate{makeServerCert()}}),
 				OptionUpstreamTLSConfig(&tls.Config{InsecureSkipVerify: true}),
 				OptionTCPGlobalRateLimiting(200.0, 200.0),
-				OptionTCPClientMaxConnections(100),
+				OptionSourceMaxConnections(100),
 				OptionEnableProxyProtocol(true, "0.0.0.0/0"),
 			)
 			defer gw.Stop()
@@ -540,7 +540,7 @@ func TestGateway(t *testing.T) {
 				OptionServerTLSConfig(&tls.Config{Certificates: []tls.Certificate{makeServerCert()}}),
 				OptionUpstreamTLSConfig(&tls.Config{InsecureSkipVerify: true}),
 				OptionTCPGlobalRateLimiting(200.0, 200.0),
-				OptionTCPClientMaxConnections(100),
+				OptionSourceMaxConnections(100),
 			)
 			defer gw.Stop()
 
@@ -582,7 +582,7 @@ func TestGateway(t *testing.T) {
 				OptionServerTLSConfig(&tls.Config{Certificates: []tls.Certificate{makeServerCert()}}),
 				OptionUpstreamTLSConfig(&tls.Config{InsecureSkipVerify: true}),
 				OptionTCPGlobalRateLimiting(200.0, 200.0),
-				OptionTCPClientMaxConnections(100),
+				OptionSourceMaxConnections(100),
 				OptionEnableProxyProtocol(true, "oopsy"),
 			)
 

--- a/gateway/options.go
+++ b/gateway/options.go
@@ -65,7 +65,6 @@ type gwconfig struct {
 	sourceExtractor                    SourceExtractor
 	metricsManager                     bahamut.MetricsManager
 	sourceRateLimitingMetricManager    LimiterMetricManager
-	tcpClientSourceExtractor           SourceExtractor
 	sourceRateExtractor                RateExtractor
 	tcpGlobalRateLimitingMetricManager LimiterMetricManager
 	exactInterceptors                  map[string]InterceptorFunc
@@ -81,7 +80,7 @@ type gwconfig struct {
 	upstreamCircuitBreakerCond         string
 	upstreamURLScheme                  string
 	additionalCorsOrigin               []string
-	tcpClientMaxConnections            int
+	clientMaxConnections               int
 	upstreamIdleConnTimeout            time.Duration
 	sourceRateLimitingRPS              rate.Limit
 	httpIdleTimeout                    time.Duration
@@ -94,7 +93,7 @@ type gwconfig struct {
 	upstreamMaxIdleConns               int
 	upstreamMaxConnsPerHost            int
 	httpWriteTimeout                   time.Duration
-	tcpClientMaxConnectionsEnabled     bool
+	clientMaxConnectionsEnabled        bool
 	upstreamUseHTTP2                   bool
 	trace                              bool
 	maintenance                        bool
@@ -130,8 +129,7 @@ func newGatewayConfig() *gwconfig {
 		httpIdleTimeout:             240 * time.Second,
 		httpReadTimeout:             120 * time.Second,
 		httpWriteTimeout:            240 * time.Second,
-		sourceExtractor:             &defaultSourceExtractor{},
-		tcpClientSourceExtractor:    &defaultTCPSourceExtractor{},
+		sourceExtractor:             &defaultIPSourceExtractor{},
 		bufferMemRequestBodyBytes:   1024 * 1024,       // 1MB
 		bufferMaxRequestBodyBytes:   100 * 1024 * 1024, // 100MB
 	}
@@ -149,8 +147,8 @@ func OptionEnableProxyProtocol(enabled bool, subnet string) Option {
 	}
 }
 
-// OptionTCPGlobalRateLimiting enables and configures the TCP rate limiter to
-// the rate of the total number of TCP connection the gateway handle.
+// OptionTCPGlobalRateLimiting configures the limiter for
+// the maximum and global number of TCP connections rate.
 func OptionTCPGlobalRateLimiting(cps rate.Limit, burst int) Option {
 	return func(cfg *gwconfig) {
 		cfg.tcpGlobalRateLimitingEnabled = true
@@ -159,32 +157,42 @@ func OptionTCPGlobalRateLimiting(cps rate.Limit, burst int) Option {
 	}
 }
 
-// OptionTCPClientMaxConnections sets the maximum number of TCP connections
-// a client can do at the same time. 0 means no limit.
-// If the sourceExtractor is nil, the default one will be used, which uses
-// the request's RemoteAddr as token.
-func OptionTCPClientMaxConnections(maxConnections int) Option {
+// OptionTCPGlobalRateLimitingMetricManager sets the LimiterMetricManager to
+// use to get metrics on the TCP global rate limiter.
+func OptionTCPGlobalRateLimitingMetricManager(m LimiterMetricManager) Option {
 	return func(cfg *gwconfig) {
-		cfg.tcpClientMaxConnectionsEnabled = maxConnections > 0
-		cfg.tcpClientMaxConnections = maxConnections
+		cfg.tcpGlobalRateLimitingMetricManager = m
 	}
 }
 
-// OptionTCPClientMaxConnectionsSourceExtractor sets the source extractor
-// to use to uniquely identify a client TCP connection.
+// OptionSourceExtractor sets the SourceExtractor to use
+// to uniquely identify a client connection.
 // The default one uses the http.Request RemoteAddr property.
 // Passing nil will reset to the default source extractor.
-func OptionTCPClientMaxConnectionsSourceExtractor(sourceExtractor SourceExtractor) Option {
+func OptionSourceExtractor(sourceExtractor SourceExtractor) Option {
 	return func(cfg *gwconfig) {
 		if sourceExtractor == nil {
-			sourceExtractor = &defaultTCPSourceExtractor{}
+			sourceExtractor = &defaultIPSourceExtractor{}
 		}
-		cfg.tcpClientSourceExtractor = sourceExtractor
+		cfg.sourceExtractor = sourceExtractor
 	}
 }
 
-// OptionSourceRateLimiting sets the rate limit for a single source.
-// If OptionSourceRateLimiting option is used, this option has no effect.
+// OptionSourceMaxConnections sets the maximum number of connections
+// a client can do at the same time. 0 means no limit.
+// A client will be identified by the SourceExtractor.
+// that can be set using OptionSourceExtractor.
+// The default SourceExtractor uses the http.Request RemoteAddr property.
+func OptionSourceMaxConnections(maxConnections int) Option {
+	return func(cfg *gwconfig) {
+		cfg.clientMaxConnectionsEnabled = maxConnections > 0
+		cfg.clientMaxConnections = maxConnections
+	}
+}
+
+// OptionSourceRateLimiting sets the rate limit for a single source identitified by
+// the current SourceExtractor.
+// If OptionSourceRateLimitingDynamic option is used, this option has no effect.
 func OptionSourceRateLimiting(rps rate.Limit, burst int) Option {
 	return func(cfg *gwconfig) {
 		cfg.sourceRateLimitingEnabled = true
@@ -194,7 +202,7 @@ func OptionSourceRateLimiting(rps rate.Limit, burst int) Option {
 }
 
 // OptionSourceRateLimitingDynamic sets the RateExtractor to use to dynamically
-// set the rates for a uniquely identified client.
+// set the rates for a uniquely identified client using the current SourceExtractor.
 // If this option is used, OptionSourceRateLimiting has no effect.
 func OptionSourceRateLimitingDynamic(rateExtractor RateExtractor) Option {
 	return func(cfg *gwconfig) {
@@ -203,16 +211,11 @@ func OptionSourceRateLimitingDynamic(rateExtractor RateExtractor) Option {
 	}
 }
 
-// OptionSourceRateLimitingSourceExtractor configures a custom SourceExtractor
-// to decide how to uniquely identify a client.
-// The default one uses a hash of the authorization header.
-// Passing nil will reset to the default source extractor.
-func OptionSourceRateLimitingSourceExtractor(sourceExtractor SourceExtractor) Option {
+// OptionSourceRateLimitingMetricManager sets the LimiterMetricManager to
+// use to get metrics on the source rate limiter.
+func OptionSourceRateLimitingMetricManager(m LimiterMetricManager) Option {
 	return func(cfg *gwconfig) {
-		if sourceExtractor == nil {
-			sourceExtractor = &defaultSourceExtractor{}
-		}
-		cfg.sourceExtractor = sourceExtractor
+		cfg.sourceRateLimitingMetricManager = m
 	}
 }
 
@@ -397,22 +400,6 @@ func OptionCORSAllowCredentials(allow bool) Option {
 func OptionTrustForwardHeader(trust bool) Option {
 	return func(cfg *gwconfig) {
 		cfg.trustForwardHeader = trust
-	}
-}
-
-// OptionTCPGlobalRateLimitingManager sets the LimiterMetricManager to
-// use to get metrics on the TCP global rate limiter.
-func OptionTCPGlobalRateLimitingManager(m LimiterMetricManager) Option {
-	return func(cfg *gwconfig) {
-		cfg.tcpGlobalRateLimitingMetricManager = m
-	}
-}
-
-// OptionSourceRateLimitingManager sets the LimiterMetricManager to
-// use to get metrics on the source rate limiter.
-func OptionSourceRateLimitingManager(m LimiterMetricManager) Option {
-	return func(cfg *gwconfig) {
-		cfg.sourceRateLimitingMetricManager = m
 	}
 }
 

--- a/gateway/options_test.go
+++ b/gateway/options_test.go
@@ -33,22 +33,22 @@ func Test_Options(t *testing.T) {
 
 	Convey("Calling OptionTCPClientMaxConnections should work", t, func() {
 		c := newGatewayConfig()
-		OptionTCPClientMaxConnections(3)(c)
-		So(c.tcpClientMaxConnectionsEnabled, ShouldEqual, true)
-		So(c.tcpClientMaxConnections, ShouldEqual, 3)
+		OptionSourceMaxConnections(3)(c)
+		So(c.clientMaxConnectionsEnabled, ShouldEqual, true)
+		So(c.clientMaxConnections, ShouldEqual, 3)
 
-		OptionTCPClientMaxConnections(0)(c)
-		So(c.tcpClientMaxConnectionsEnabled, ShouldEqual, false)
-		So(c.tcpClientMaxConnections, ShouldEqual, 0)
+		OptionSourceMaxConnections(0)(c)
+		So(c.clientMaxConnectionsEnabled, ShouldEqual, false)
+		So(c.clientMaxConnections, ShouldEqual, 0)
 	})
 
-	Convey("Calling OptionTCPClientMaxConnectionsSourceExtractor should work", t, func() {
+	Convey("Calling OptionSourceExtractor should work", t, func() {
 		c := newGatewayConfig()
-		OptionTCPClientMaxConnectionsSourceExtractor(nil)(c)
-		So(c.tcpClientSourceExtractor, ShouldHaveSameTypeAs, &defaultTCPSourceExtractor{})
-		se := &defaultTCPSourceExtractor{}
-		OptionTCPClientMaxConnectionsSourceExtractor(se)(c)
-		So(c.tcpClientSourceExtractor, ShouldEqual, se)
+		OptionSourceExtractor(nil)(c)
+		So(c.sourceExtractor, ShouldHaveSameTypeAs, &defaultIPSourceExtractor{})
+		se := &defaultIPSourceExtractor{}
+		OptionSourceExtractor(se)(c)
+		So(c.sourceExtractor, ShouldEqual, se)
 	})
 
 	Convey("Calling OptionSourceRateLimiting should work", t, func() {
@@ -64,15 +64,6 @@ func Test_Options(t *testing.T) {
 		re := RateExtractor(nil)
 		OptionSourceRateLimitingDynamic(re)(c)
 		So(c.sourceRateExtractor, ShouldEqual, re)
-	})
-
-	Convey("Calling OptionSourceRateLimitingSourceExtractor should work", t, func() {
-		c := newGatewayConfig()
-		OptionSourceRateLimitingSourceExtractor(nil)(c)
-		So(c.sourceExtractor, ShouldHaveSameTypeAs, &defaultSourceExtractor{})
-		se := &defaultTCPSourceExtractor{}
-		OptionSourceRateLimitingSourceExtractor(se)(c)
-		So(c.sourceExtractor, ShouldEqual, se)
 	})
 
 	Convey("Calling OptionEnableTrace should work", t, func() {
@@ -225,14 +216,14 @@ func Test_Options(t *testing.T) {
 	Convey("Calling OptionTCPGlobalRateLimitingManager should work", t, func() {
 		c := newGatewayConfig()
 		m := &fakeListenerLimiterMetricManager{}
-		OptionTCPGlobalRateLimitingManager(m)(c)
+		OptionTCPGlobalRateLimitingMetricManager(m)(c)
 		So(c.tcpGlobalRateLimitingMetricManager, ShouldEqual, m)
 	})
 
 	Convey("Calling OptionSourceRateLimitingManager should work", t, func() {
 		c := newGatewayConfig()
 		m := &fakeListenerLimiterMetricManager{}
-		OptionSourceRateLimitingManager(m)(c)
+		OptionSourceRateLimitingMetricManager(m)(c)
 		So(c.sourceRateLimitingMetricManager, ShouldEqual, m)
 	})
 


### PR DESCRIPTION
A lot of things were confusing, so realign all option and rename them to match what they actually really do.