### PR TITLE
fix: register parent-route DELETE/PUT in REST + push correct verbs

### DIFF
--- a/gateway/upstreamer/push/notifier_test.go
+++ b/gateway/upstreamer/push/notifier_test.go
@@ -114,7 +114,11 @@ func TestNonNotifier(t *testing.T) {
 							checked++
 						}
 					}
-					So(checked, ShouldEqual, 5)
+					// 4 unique URLs total across the test model:
+					//   /lists, /lists/:id, /lists/:id/tasks, /tasks/:id
+					// Was 5 before the buildVersionedRoutes fix that no longer
+					// emits a phantom POST /tasks for parent-only Create.
+					So(checked, ShouldEqual, 4)
 
 					Convey("Then I wait 1.5sec and I should get another pusb", func() {
 

--- a/meta.go
+++ b/meta.go
@@ -68,20 +68,8 @@ func buildVersionedRoutes(modelManagers map[int]elemental.ModelManager, processo
 				continue
 			}
 
-			if len(relationship.Create) > 0 {
-				addRoute(routes, identity, fmt.Sprintf("/%s", identity.Category), "POST", identity.Private)
-			}
-
 			if len(relationship.Retrieve) > 0 {
 				addRoute(routes, identity, fmt.Sprintf("/%s/:id", identity.Category), "GET", identity.Private)
-			}
-
-			if len(relationship.Delete) > 0 {
-				addRoute(routes, identity, fmt.Sprintf("/%s/:id", identity.Category), "DELETE", identity.Private)
-			}
-
-			if len(relationship.Update) > 0 {
-				addRoute(routes, identity, fmt.Sprintf("/%s/:id", identity.Category), "PUT", identity.Private)
 			}
 
 			for parent := range relationship.RetrieveMany {
@@ -99,6 +87,24 @@ func buildVersionedRoutes(modelManagers map[int]elemental.ModelManager, processo
 					addRoute(routes, identity, fmt.Sprintf("/%s", identity.Category), "POST", identity.Private)
 				} else {
 					addRoute(routes, identity, fmt.Sprintf("/%s/:id/%s", modelManager.IdentityFromName(parent).Category, identity.Category), "POST", identity.Private)
+				}
+			}
+
+			for parent := range relationship.Delete {
+
+				if parent == "root" {
+					addRoute(routes, identity, fmt.Sprintf("/%s/:id", identity.Category), "DELETE", identity.Private)
+				} else {
+					addRoute(routes, identity, fmt.Sprintf("/%s/:id/%s", modelManager.IdentityFromName(parent).Category, identity.Category), "DELETE", identity.Private)
+				}
+			}
+
+			for parent := range relationship.Update {
+
+				if parent == "root" {
+					addRoute(routes, identity, fmt.Sprintf("/%s/:id", identity.Category), "PUT", identity.Private)
+				} else {
+					addRoute(routes, identity, fmt.Sprintf("/%s/:id/%s", modelManager.IdentityFromName(parent).Category, identity.Category), "PUT", identity.Private)
 				}
 			}
 		}

--- a/meta_test.go
+++ b/meta_test.go
@@ -73,13 +73,6 @@ func Test_buildVersionedRoutes(t *testing.T) {
 						},
 					},
 					{
-						URL:      "/tasks",
-						Identity: "tasks",
-						Verbs: []string{
-							"POST",
-						},
-					},
-					{
 						URL:      "/tasks/:id",
 						Identity: "tasks",
 						Verbs: []string{
@@ -137,13 +130,6 @@ func Test_buildVersionedRoutes(t *testing.T) {
 						Identity: "users",
 						Verbs: []string{
 							"GET",
-						},
-					},
-					{
-						URL:      "/tasks",
-						Identity: "tasks",
-						Verbs: []string{
-							"POST",
 						},
 					},
 					{

--- a/rest_server.go
+++ b/rest_server.go
@@ -182,6 +182,8 @@ func (a *restServer) installRoutes(routesInfo map[int][]RouteInfo) {
 	a.multiplexer.Get(path.Join(a.cfg.restServer.apiPrefix, "/:parentcategory/:id/:category"), a.makeHandler(handleRetrieveMany))
 	a.multiplexer.Post(path.Join(a.cfg.restServer.apiPrefix, "/:category"), a.makeHandler(handleCreate))
 	a.multiplexer.Post(path.Join(a.cfg.restServer.apiPrefix, "/:parentcategory/:id/:category"), a.makeHandler(handleCreate))
+	a.multiplexer.Put(path.Join(a.cfg.restServer.apiPrefix, "/:parentcategory/:id/:category"), a.makeHandler(handleUpdate))
+	a.multiplexer.Delete(path.Join(a.cfg.restServer.apiPrefix, "/:parentcategory/:id/:category"), a.makeHandler(handleDelete))
 	a.multiplexer.Head(path.Join(a.cfg.restServer.apiPrefix, "/:category"), a.makeHandler(handleInfo))
 	a.multiplexer.Head(path.Join(a.cfg.restServer.apiPrefix, "/:parentcategory/:id/:category"), a.makeHandler(handleInfo))
 
@@ -194,6 +196,8 @@ func (a *restServer) installRoutes(routesInfo map[int][]RouteInfo) {
 	a.multiplexer.Get(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:parentcategory/:id/:category"), a.makeHandler(handleRetrieveMany))
 	a.multiplexer.Post(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:category"), a.makeHandler(handleCreate))
 	a.multiplexer.Post(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:parentcategory/:id/:category"), a.makeHandler(handleCreate))
+	a.multiplexer.Put(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:parentcategory/:id/:category"), a.makeHandler(handleUpdate))
+	a.multiplexer.Delete(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:parentcategory/:id/:category"), a.makeHandler(handleDelete))
 	a.multiplexer.Head(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:category"), a.makeHandler(handleInfo))
 	a.multiplexer.Head(path.Join(a.cfg.restServer.apiPrefix, "/v/:version/:parentcategory/:id/:category"), a.makeHandler(handleInfo))
 

--- a/rest_server_test.go
+++ b/rest_server_test.go
@@ -158,10 +158,10 @@ func TestServer_RouteInstallation(t *testing.T) {
 			Convey("Then the bone Multiplexer should have correct number of handlers", func() {
 				So(len(c.multiplexer.Routes[http.MethodPost]), ShouldEqual, 5)
 				So(len(c.multiplexer.Routes[http.MethodGet]), ShouldEqual, 10)
-				So(len(c.multiplexer.Routes[http.MethodDelete]), ShouldEqual, 3)
+				So(len(c.multiplexer.Routes[http.MethodDelete]), ShouldEqual, 5)
 				So(len(c.multiplexer.Routes[http.MethodPatch]), ShouldEqual, 3)
 				So(len(c.multiplexer.Routes[http.MethodHead]), ShouldEqual, 5)
-				So(len(c.multiplexer.Routes[http.MethodPut]), ShouldEqual, 3)
+				So(len(c.multiplexer.Routes[http.MethodPut]), ShouldEqual, 5)
 			})
 		})
 	})
@@ -209,10 +209,10 @@ func TestServer_RouteInstallation(t *testing.T) {
 			Convey("Then the bone Multiplexer should have correct number of handlers", func() {
 				So(len(c.multiplexer.Routes[http.MethodPost]), ShouldEqual, 6)
 				So(len(c.multiplexer.Routes[http.MethodGet]), ShouldEqual, 11)
-				So(len(c.multiplexer.Routes[http.MethodDelete]), ShouldEqual, 4)
+				So(len(c.multiplexer.Routes[http.MethodDelete]), ShouldEqual, 6)
 				So(len(c.multiplexer.Routes[http.MethodPatch]), ShouldEqual, 4)
 				So(len(c.multiplexer.Routes[http.MethodHead]), ShouldEqual, 6)
-				So(len(c.multiplexer.Routes[http.MethodPut]), ShouldEqual, 4)
+				So(len(c.multiplexer.Routes[http.MethodPut]), ShouldEqual, 6)
 			})
 
 			Convey("The routes must have the correct prefix", func() {


### PR DESCRIPTION
The REST multiplexer only registered POST/GET/HEAD against the 3-segment `/:parentcategory/:id/:category` pattern, so DELETE and PUT against a child collection (e.g. `DELETE /apps/:id/appcomponents`, `DELETE /gateways/:id/apptokens`) returned 405 from the bone router before reaching any handler. Add the missing Delete and Update routes on both the non-versioned and versioned multiplexer paths.

buildVersionedRoutes also under-described what the server actually handled: the standalone `if len(relationship.Create|Delete|Update) > 0` blocks emitted root-shaped URLs (`/category`, `/category/:id`) even for relationships that only had non-root parents (e.g. a model with Create["list"] but no Create["root"] still got a phantom POST /category announcement). Replace those blocks with per-parent loops mirroring the existing RetrieveMany/Create handling, so each parent gets the correct URL shape (root → flat, non-root → /parent/:id/category) and parent-only relationships no longer announce phantom root URLs.

Test expectations updated for the corrected behavior; the previous test data was asserting on the buggy phantom-URL output.